### PR TITLE
Немного туповатая оптимизация

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,14 @@ regex = "1"
 lazy_static = "1"
 rand_pcg = "0.2"
 rand = "0.7"
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,31 +47,55 @@ fn update<K>(m: &mut HashMap<K, usize>, k: K, delta: isize)
     if new_v > 0 { m.insert(k, new_v as usize); }
     else { m.remove(&k); }
 }
+lazy_static! {
+    static ref BLOCKER0_0: Vec<Point> = vec![Point::new(0, 0)];
+    static ref BLOCKER1_M1: Vec<Point> = vec![Point::new(1, -1)];
+    static ref BLOCKER1_0: Vec<Point> = vec![Point::new(1, 0)];
+    static ref BLOCKER1_1: Vec<Point> = vec![Point::new(1, 1)];
+    static ref BLOCKER2: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 1, y: 1}, Point{x: 1, y: 2}, Point{x: 1, y: 3}];
+    static ref BLOCKER3: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 1, y: 2}, Point{x: 1, y: 3}, Point{x: 1, y: 4}];
+    static ref BLOCKER4: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 1, y: 2}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}];
+    static ref BLOCKER5: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}];
+    static ref BLOCKER6: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}];
+    static ref BLOCKER7: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}];
+    static ref BLOCKER8: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}];
+    static ref BLOCKER9: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}];
+    static ref BLOCKER10: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}];
+    static ref BLOCKER11: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}];
+    static ref BLOCKER12: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}];
+    static ref BLOCKER13: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}];
+    static ref BLOCKER14: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}];
+    static ref BLOCKER15: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}];
+    static ref BLOCKER16: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}];
+    static ref BLOCKER17: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}];
+    static ref BLOCKER18: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 0, y: 10}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}, Point{x: 1, y: 19}];
+    static ref BLOCKER19: Vec<Point> = vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 0, y: 10}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}, Point{x: 1, y: 19}, Point{x: 1, y: 20}];
+}
 
-fn hand_blocker(p: &Point) -> Vec<Point> {
+fn hand_blocker(p: &Point) -> &Vec<Point> {
     match p {
-        Point{x: 0, y: 0}  => vec![Point::new(0, 0)],
-        Point{x: 1, y: -1} => vec![Point::new(1, -1)],
-        Point{x: 1, y: 0}  => vec![Point::new(1, 0)],
-        Point{x: 1, y: 1}  => vec![Point::new(1, 1)],
-        Point{x: 1, y: 2} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 1, y: 1}, Point{x: 1, y: 2}, Point{x: 1, y: 3}],
-        Point{x: 1, y: 3} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 1, y: 2}, Point{x: 1, y: 3}, Point{x: 1, y: 4}],
-        Point{x: 1, y: 4} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 1, y: 2}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}],
-        Point{x: 1, y: 5} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}],
-        Point{x: 1, y: 6} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}],
-        Point{x: 1, y: 7} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}],
-        Point{x: 1, y: 8} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}],
-        Point{x: 1, y: 9} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}],
-        Point{x: 1, y: 10} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}],
-        Point{x: 1, y: 11} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}],
-        Point{x: 1, y: 12} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}],
-        Point{x: 1, y: 13} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}],
-        Point{x: 1, y: 14} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}],
-        Point{x: 1, y: 15} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}],
-        Point{x: 1, y: 16} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}],
-        Point{x: 1, y: 17} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}],
-        Point{x: 1, y: 18} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 0, y: 10}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}, Point{x: 1, y: 19}],
-        Point{x: 1, y: 19} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 0, y: 10}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}, Point{x: 1, y: 19}, Point{x: 1, y: 20}],
+        Point{x: 0, y: 0}  => &BLOCKER0_0,
+        Point{x: 1, y: -1} => &BLOCKER1_M1,
+        Point{x: 1, y: 0}  => &BLOCKER1_0,
+        Point{x: 1, y: 1}  => &BLOCKER1_1,
+        Point{x: 1, y: 2} => &BLOCKER2,
+        Point{x: 1, y: 3} => &BLOCKER3,
+        Point{x: 1, y: 4} => &BLOCKER4,
+        Point{x: 1, y: 5} => &BLOCKER5,
+        Point{x: 1, y: 6} => &BLOCKER6,
+        Point{x: 1, y: 7} => &BLOCKER7,
+        Point{x: 1, y: 8} => &BLOCKER8,
+        Point{x: 1, y: 9} => &BLOCKER9,
+        Point{x: 1, y: 10} => &BLOCKER10,
+        Point{x: 1, y: 11} => &BLOCKER11,
+        Point{x: 1, y: 12} => &BLOCKER12,
+        Point{x: 1, y: 13} => &BLOCKER13,
+        Point{x: 1, y: 14} => &BLOCKER14,
+        Point{x: 1, y: 15} => &BLOCKER15,
+        Point{x: 1, y: 16} => &BLOCKER16,
+        Point{x: 1, y: 17} => &BLOCKER17,
+        Point{x: 1, y: 18} => &BLOCKER18,
+        Point{x: 1, y: 19} => &BLOCKER19,
         _ => unimplemented!()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,30 +48,39 @@ fn update<K>(m: &mut HashMap<K, usize>, k: K, delta: isize)
     else { m.remove(&k); }
 }
 
-fn hand_blockers() -> HashMap<Point, Vec<Point>> {
-    let mut res = HashMap::new();
-    res.insert(Point::new(0,  0), vec![Point::new(0,  0)]);
-    res.insert(Point::new(1, -1), vec![Point::new(1, -1)]);
-    res.insert(Point::new(1,  0), vec![Point::new(1,  0)]);
-    res.insert(Point::new(1,  1), vec![Point::new(1,  1)]);
-    for maxy in 2..19 {
-        let mut val = Vec::with_capacity(maxy);
-        for y in 1..(maxy/2+1) { val.push(Point::new(0, y as isize)) }
-        for y in (maxy+1)/2..(maxy+1) { val.push(Point::new(1, y as isize)) }
-        res.insert(Point::new(1, maxy as isize), val);
+fn hand_blocker(p: &Point) -> Vec<Point> {
+    match p {
+        Point{x: 0, y: 0}  => vec![Point::new(0, 0)],
+        Point{x: 1, y: -1} => vec![Point::new(1, -1)],
+        Point{x: 1, y: 0}  => vec![Point::new(1, 0)],
+        Point{x: 1, y: 1}  => vec![Point::new(1, 1)],
+        Point{x: 1, y: 2} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 1, y: 1}, Point{x: 1, y: 2}, Point{x: 1, y: 3}],
+        Point{x: 1, y: 3} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 1, y: 2}, Point{x: 1, y: 3}, Point{x: 1, y: 4}],
+        Point{x: 1, y: 4} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 1, y: 2}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}],
+        Point{x: 1, y: 5} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}],
+        Point{x: 1, y: 6} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 1, y: 3}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}],
+        Point{x: 1, y: 7} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}],
+        Point{x: 1, y: 8} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 1, y: 4}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}],
+        Point{x: 1, y: 9} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}],
+        Point{x: 1, y: 10} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 1, y: 5}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}],
+        Point{x: 1, y: 11} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}],
+        Point{x: 1, y: 12} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 1, y: 6}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}],
+        Point{x: 1, y: 13} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}],
+        Point{x: 1, y: 14} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 1, y: 7}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}],
+        Point{x: 1, y: 15} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}],
+        Point{x: 1, y: 16} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 1, y: 8}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}],
+        Point{x: 1, y: 17} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}],
+        Point{x: 1, y: 18} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 0, y: 10}, Point{x: 1, y: 9}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}, Point{x: 1, y: 19}],
+        Point{x: 1, y: 19} => vec![Point{x: 0, y: 1}, Point{x: 0, y: 2}, Point{x: 0, y: 3}, Point{x: 0, y: 4}, Point{x: 0, y: 5}, Point{x: 0, y: 6}, Point{x: 0, y: 7}, Point{x: 0, y: 8}, Point{x: 0, y: 9}, Point{x: 0, y: 10}, Point{x: 1, y: 10}, Point{x: 1, y: 11}, Point{x: 1, y: 12}, Point{x: 1, y: 13}, Point{x: 1, y: 14}, Point{x: 1, y: 15}, Point{x: 1, y: 16}, Point{x: 1, y: 17}, Point{x: 1, y: 18}, Point{x: 1, y: 19}, Point{x: 1, y: 20}],
+        _ => unimplemented!()
     }
-    res
-}
-
-lazy_static! {
-    static ref HAND_BLOCKERS: HashMap<Point, Vec<Point>> = hand_blockers();
 }
 
 type Zone = u8;
 const UNDECIDED_ZONE: Zone = !0;
 fn zone_char(zone: Zone) -> char {
     if zone < UNDECIDED_ZONE { (65 + zone) as char }
-    else { '-' } 
+    else { '-' }
 }
 
 pub struct Drone {
@@ -86,7 +95,7 @@ pub struct Drone {
 
 impl Drone {
     fn new(pos: Point) -> Drone {
-        Drone { pos, 
+        Drone { pos,
                 hands:  vec![Point::new(0,0), Point::new(1,-1), Point::new(1,0), Point::new(1,1)],
                 wheels: 0,
                 drill:  0,
@@ -203,10 +212,10 @@ impl Drone {
         let drill = self.drill > 0;
         if let Some((pos, new_wrapped, new_drilled)) = step(level, self, &self.pos, action, wheels, drill, &HashSet::new()) {
             self.pos = pos;
-            match action { 
-                Action::UP    => self.path += "W", 
-                Action::DOWN  => self.path += "S", 
-                Action::LEFT  => self.path += "A", 
+            match action {
+                Action::UP    => self.path += "W",
+                Action::DOWN  => self.path += "S",
+                Action::LEFT  => self.path += "A",
                 Action::RIGHT => self.path += "D",
                 Action::JUMP0 => self.path += &format!("T({},{})", level.beakons[0].x, level.beakons[0].y),
                 Action::JUMP1 => self.path += &format!("T({},{})", level.beakons[1].x, level.beakons[1].y),
@@ -239,7 +248,7 @@ pub struct Level {
 }
 
 impl Level {
-    fn grid_idx(&self, x: isize, y: isize) -> usize {        
+    fn grid_idx(&self, x: isize, y: isize) -> usize {
         (x + y * self.width) as usize
     }
 
@@ -349,7 +358,7 @@ fn max_wrapping(level: &Level, drone: &Drone, pos: &Point) -> f64 {
 }
 
 fn is_reaching(level: &Level, from: &Point, hand: &Point) -> bool {
-    HAND_BLOCKERS.get(hand).unwrap().iter().all(|p| level.walkable(from.x+p.x, from.y+p.y))
+    hand_blocker(hand).iter().all(|p| level.walkable(from.x+p.x, from.y+p.y))
 }
 
 fn would_wrap(level: &Level, drone: &Drone, pos: &Point, wrapped: &mut HashSet<Point>) {
@@ -448,7 +457,7 @@ fn explore_impl<F>(level: &Level, drone: &Drone, rate: F) -> Option<(VecDeque<Ac
             } else {
                 if score > 0. { best = Some((plan.clone(), pos, score)); }
             }
-            
+
             for action in &[Action::LEFT, Action::RIGHT, Action::UP, Action::DOWN, Action::JUMP0, Action::JUMP1, Action::JUMP2] {
                 if let Some((pos2, new_wrapped, new_drilled)) = step(level, drone, &pos, action, wheels > 0, drill > 0, &drilled) {
                     if seen.contains(&pos2) { continue; }
@@ -463,7 +472,7 @@ fn explore_impl<F>(level: &Level, drone: &Drone, rate: F) -> Option<(VecDeque<Ac
                         wheels:  if wheels > 1 { wheels - 1 } else { 0 },
                         drill:   if drill > 1  { drill - 1 }  else { 0 },
                         drilled: drilled2
-                    });    
+                    });
                 }
             }
         } else { break best }
@@ -520,7 +529,7 @@ fn solve_impl(level: &mut Level, drones: &mut Vec<Drone>, interactive: bool) -> 
             drone.collect(level);
             drone.wear_off();
             drone.choose_zone(&taken, level);
-            
+
             if drone.plan.is_empty() {
                 if let Some(clone) = drone.reduplicate(level) {
                     drones.push(clone);
@@ -539,7 +548,7 @@ fn solve_impl(level: &mut Level, drones: &mut Vec<Drone>, interactive: bool) -> 
                     drone.plan = plan;
                 }
             }
-            
+
             if let Some(action) = drone.plan.pop_front() {
                 drone.act(&action, level);
             } else if drone.wheels > 0 {
@@ -549,12 +558,12 @@ fn solve_impl(level: &mut Level, drones: &mut Vec<Drone>, interactive: bool) -> 
             }
         }
     }
-    
+
     if interactive {
         print_state(level, drones);
         println!("\x1B[?1049l");
     }
-    
+
     let paths: Vec<&str> = drones.iter().map(|d| d.path.as_str()).collect();
     paths.join("#")
 }
@@ -586,7 +595,7 @@ fn doall<T, F>(tasks: VecDeque<T>, threads: usize, f: F)
     for i in 0..threads {
         let m_queue = Arc::clone(&m_queue);
         let handle = thread::spawn(move || loop {
-            let o_task = { 
+            let o_task = {
                 let mut queue = m_queue.lock().unwrap();
                 queue.pop_front()
             };
@@ -611,19 +620,19 @@ fn main() {
     let mut interactive = false;
     let mut threads = 1;
     let mut filenames: VecDeque<String> = VecDeque::new();
-    
+
     for arg in args[1..].iter() {
         if arg == "--interactive" {
             interactive = true;
         } else if let Some(caps) = threads_re.captures(arg) {
             threads = caps.get(1).unwrap().as_str().parse::<isize>().unwrap() as usize;
-        } else if arg.ends_with(".desc") { 
+        } else if arg.ends_with(".desc") {
             filenames.push_back(arg.clone());
-        } else { 
+        } else {
             panic!("cargo run --release [--interactive] [--threads=N] <path/to/problem.desc>");
         }
     }
-    
+
     let tasks = filenames.len();
     doall(filenames, threads, move |f| solve(&f, interactive));
     if tasks > 1 {


### PR DESCRIPTION
По следам https://tonsky.livejournal.com/322450.html?thread=5466770#t5466770

У меня выдалось свободных полчаса, и я посмотрел, нет ли тупого способа приподускорить этот код.
Получилось вдвое, с 3816±188 до 1756±66 мсек (на конкретно моём ноуте с линуксом, мерял по выбранной наобум задаче 272).

По шагам (каждый шаг — один коммит):

1. Я тупо включил Link-Time Optimizer. Минус десять процентов. Пришлось пожертвовать скоростью компиляции (принудительно сделав один codegen-unit), так линкер лучше видит глобальную картинку и оптимальнее оптимизирует. Также заменил паники на abort, это тоже должно быть побыстрее, а нам всё равно не нужен бектрейс в релизе.

2. Окей, прогнал Callgrind, увидел что дороже всего обходится хешинг при чтении из `HAND_BLOCKERS`. Заменил его втупую на матчинг, сократил время пробега с 3.4 до 2.3 секунды. (Хеш-мапы — дорогие, потому что прогоняют хеширование у ключа на каждое чтение и запись. Если можно заменить на цепочки ифов — стоит заменить на цепочку ифов).  
Тут я считерил, и заменил код из lazy_static на вручную прописанные вектора, которые сгенерил скриптом на руби по изначальному (вроде бы) алгоритму. Если где-то и закралась ошибка — то именно тут. На измерения перформанса она точно не влияет.

3. Так, но теперь мы аллоцируем эти вектора на каждый чих — это тоже так себе. Выносим их в статики; можно бы и вернуть обратно их алгоритмический рассчёт, но лень (а на перформанс не влияет). Ещё минус 20%, 1.7 секунды в итоге.


Вот. Следующий шаг будет — заменить хешмэп в `would_wrap` на двумерный битмап. Да, будет дофига нулей в большущем двумерном массиве. Но скорее всего там не такие большие размеры, чтобы эта память чего-нибудь стоила — но по Callgrind это опять узкое место, и опять дело в хешировании для HashSet.

Кажется, что ещё за 2-4 итерации ещё раза 2-3 будет легко выиграть.
Всё это я делал по-прежнему не вникая в детали алгоритма, чтобы не начать случайно алгоритмически оптимизировать.